### PR TITLE
extract repeated mixed content pattern into variable in schema

### DIFF
--- a/norseTalesSchema.rnc
+++ b/norseTalesSchema.rnc
@@ -1,32 +1,30 @@
 start = story
-
 story = element story { title, body }
-
 title = element title { text }
-
 body = element body { p }
-
-p = element p { mixed{(character | dialogue | action | descriptor | 
-transformation | fig_lang | misconception)*} }
-
+#
+# #####
+# mixed pattern used in multiple content models
+# #####
+#
+textual_content =
+    mixed { (character | action | descriptor | transformation | fig_lang | misconception)* }
+p = element p { textual_content }
+#
+# #####
+# elements and attributes
+# #####
+#
 character = element character { text }
-dialogue = element dialogue { speaker, subject, mixed{(character | action | descriptor | 
-transformation | fig_lang | misconception)*} }
-
+dialogue = element dialogue { speaker, subject, textual_content }
 speaker = attribute speaker { text }
-
 action = element action { actor, subject, text }
 descriptor = element descriptor { speaker, subject, text }
-
 actor = attribute actor { text }
 subject = attribute subject { text }
-
 transformation = element transformation { form, subject, text }
-
 form = attribute form { text }
-
-fig_lang = element fig_lang {type, relation*, subject, text}
+fig_lang = element fig_lang { type, relation*, subject, text }
 type = attribute type { text }
 relation = attribute relation { text }
-
-misconception = element misconception { actor, subject, text}
+misconception = element misconception { actor, subject, text }


### PR DESCRIPTION
Two elements in the schema (`<p>`, `<dialogue>`)used almost the same mixed-content models, so I extracted that pattern into its own named pattern ("textual_content") and used that as a replacement for the full pattern. The suggestion makes sense in its current form, though, only if you really want to allow exactly the same content in both places. Since the original content models differed slightly in the elements they allowed, if those differences are important, I would recommend rejected the PR.